### PR TITLE
Bump poi in /others/code/springboot-kubernetes/03-notifications-service

### DIFF
--- a/others/code/springboot-kubernetes/03-notifications-service/pom.xml
+++ b/others/code/springboot-kubernetes/03-notifications-service/pom.xml
@@ -86,7 +86,7 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>3.15</version>
+			<version>4.1.1</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Bumps poi from 3.15 to 4.1.1.

---
updated-dependencies:
- dependency-name: org.apache.poi:poi dependency-type: direct:production ...